### PR TITLE
Adds auto-deleting of unconvertable files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 Convert Google Voice SMS data from Takeout to .xml suitable for use with SMS Backup and Restore.
 Input data is a folder of .html, image, and vCard files from Google Takeout.
 
-Working as of Jan 30, 2024.
+Working as of September 21, 2024.
 
-This is forked from codecivet, mostly due to some issues I encountered when using his script. I am by no means a professional coder of anything, and I used a decent amount of help from ChatGPT to get this thing working, so YMMV. 
+This is forked from SLAB-8002, mostly to optionally auto-remove conversations that weren't convertable and were mostly spam, automated messages, etc. 
+
+## Improvements from SLAB-8002
+* Offers to auto-delete conversations that will cause issues and are generally not wanted, e.g. converations without attached phone numbers.
+
+After removing those files my conversion of 145,201 messages, 5061 images, and 14 contact cards succeeded in 6 minutes, 30 seconds.
 
 ## Improvements from codecivet fork
 * Removes the "MMS Sent" and "MMS Received" messages mentioned by codecivet.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Input data is a folder of .html, image, and vCard files from Google Takeout.
 
 Working as of September 21, 2024.
 
-This is forked from SLAB-8002, mostly to optionally auto-remove conversations that weren't convertable and were mostly spam, automated messages, etc. 
+This is forked from [SLAB-8002(https://github.com/SLAB-8002), mostly to optionally auto-remove conversations that weren't convertable and were mostly spam, automated messages, etc. 
 
 ## Improvements from SLAB-8002
 * Offers to auto-delete conversations that will cause issues and are generally not wanted, e.g. converations without attached phone numbers.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Input data is a folder of .html, image, and vCard files from Google Takeout.
 
 Working as of September 21, 2024.
 
-This is forked from [SLAB-8002(https://github.com/SLAB-8002), mostly to optionally auto-remove conversations that weren't convertable and were mostly spam, automated messages, etc. 
+This is forked from [SLAB-8002](https://github.com/SLAB-8002), mostly to optionally auto-remove conversations that weren't convertable and were mostly spam, automated messages, etc. 
 
 ## Improvements from SLAB-8002
 * Offers to auto-delete conversations that will cause issues and are generally not wanted, e.g. converations without attached phone numbers.

--- a/sms.py
+++ b/sms.py
@@ -95,9 +95,11 @@ def main():
 def remove_problematic_files():
     #Get user confimration before deleteing files
     user_confirmation = input("""\
-    Would you like to automatically remove converstaions that won't convert?
-    This is converations without attached phone numbers or ones with shortcode phone numbers.
-    If so, this will automatically delete those files.
+
+    Would you like to automatically remove conversations that won't convert?
+    This is conversations without attached phone numbers, ones with shortcode phone numbers,
+    or things like missed calls and voicemails.
+    If you say yes, this will automatically delete those files before converting.
     (Y/n)? """)
     if user_confirmation == '' or user_confirmation == 'y' or user_confirmation == 'Y':
         # Find files starting with " -" instead of a phone number


### PR DESCRIPTION
I tweaked this script a bit to remove conversations that couldn't be converted such as conversations with shortcode numbers, without numbers at all, etc. No pressure to accept but wanted to send a PR in case it was useful.

(Also, thanks a ton, this script solved a huge issue for me!)